### PR TITLE
Add ll_trace crate — Chrome Trace Format reporter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ The key use case is instrumenting complex async workflows (e.g. a CLI tool orche
 ll/              core engine — compiles for native + WASM
 ll_macros/       #[task] proc macro
 ll_stdio/        terminal reporters (StdioReporter, StringReporter, TermStatus)
+ll_trace/        Chrome Trace Format reporter (TraceReporter → JSON file)
 ll_wasm/         WASM reporter (ConsoleReporter → JS console)
 test/
   ll_fixtures/   reusable fixture task trees for testing
@@ -43,6 +44,9 @@ ll_stdio (separate crate):
 
 ll_wasm (separate crate):
    └── ConsoleReporter  JS console.log/error (setInterval drain)
+
+ll_trace (separate crate):
+   └── TraceReporter    Chrome Trace JSON to file (background drain thread)
 ```
 
 ### Key concepts
@@ -87,6 +91,10 @@ ll_stdio/src/
 ll_wasm/src/
   lib.rs              crate root
   console_reporter.rs ConsoleReporter (JS console via web_sys)
+
+ll_trace/src/
+  lib.rs              TraceReporter, Builder, init(), FlushGuard
+  writer.rs           Chrome Trace JSON event serialization
 
 ll_macros/src/
   lib.rs              #[task] proc macro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ll",
     "ll_macros",
     "ll_stdio",
+    "ll_trace",
     "ll_wasm",
     "test/ll_fixtures",
     "test/ll_test_cli",

--- a/ll_trace/Cargo.toml
+++ b/ll_trace/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ll_trace"
+version = "10.0.0"
+edition = "2018"
+authors = ["Aaron Abrams <aaron@abrams.cc>"]
+description = "Chrome Trace Format reporter for ll — write trace JSON viewable in chrome://tracing and Perfetto"
+license = "MIT"
+repository = "https://github.com/boujeepossum/ll"
+
+[dependencies]
+ll = { version = "10.0.0", path = "../ll" }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+web-time = "0.2"
+
+[dev-dependencies]
+k9 = "0.12"
+tokio = { version = "1", features = ["full"] }

--- a/ll_trace/src/lib.rs
+++ b/ll_trace/src/lib.rs
@@ -1,0 +1,199 @@
+/*!
+Chrome Trace Format reporter for [`ll`]. Writes trace JSON viewable in
+`chrome://tracing` or [Perfetto UI](https://ui.perfetto.dev).
+
+Each finished task becomes one complete (`X`) event with timestamp, duration,
+and optional metadata. The output streams to any `Write` destination — file,
+buffer, or pipe.
+
+Quick setup:
+```ignore
+ll_trace::init("trace.json");  // writes trace.json, returns FlushGuard
+```
+
+Builder for more control:
+```ignore
+let _guard = ll_trace::builder()
+    .file("trace.json")
+    .process_name("my-server")
+    .include_args(true)
+    .build();
+```
+
+**Important:** Hold the returned [`FlushGuard`] until you want to finalize
+the trace file. Dropping it writes the closing `]}` and flushes the writer.
+*/
+
+pub mod writer;
+
+use ll::reporters::{EventQueue, Reporter};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use web_time::SystemTime;
+
+// ── Public API ──────────────────────────────────────────────────
+
+/// Initialize a trace reporter that writes to `path`. Returns a
+/// [`FlushGuard`] — hold it until shutdown, then drop to finalize.
+pub fn init(path: &str) -> FlushGuard {
+    builder().file(path).build()
+}
+
+pub fn builder() -> Builder {
+    Builder::default()
+}
+
+// ── Builder ─────────────────────────────────────────────────────
+
+pub struct Builder {
+    process_name: String,
+    include_args: bool,
+    include_tags: bool,
+    writer: Option<Box<dyn Write + Send>>,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            process_name: "ll".into(),
+            include_args: true,
+            include_tags: true,
+            writer: None,
+        }
+    }
+}
+
+impl Builder {
+    pub fn file(mut self, path: &str) -> Self {
+        let f = File::create(path).expect("failed to create trace file");
+        self.writer = Some(Box::new(BufWriter::new(f)));
+        self
+    }
+
+    pub fn writer(mut self, w: impl Write + Send + 'static) -> Self {
+        self.writer = Some(Box::new(w));
+        self
+    }
+
+    pub fn process_name(mut self, name: &str) -> Self {
+        self.process_name = name.into();
+        self
+    }
+
+    pub fn include_args(mut self, val: bool) -> Self {
+        self.include_args = val;
+        self
+    }
+
+    pub fn include_tags(mut self, val: bool) -> Self {
+        self.include_tags = val;
+        self
+    }
+
+    /// Build the reporter and register it on the global [`ll::TaskTree`].
+    pub fn build(self) -> FlushGuard {
+        let (reporter, guard) = self.build_reporter();
+        ll::add_reporter(reporter);
+        guard
+    }
+
+    /// Build the reporter without registering it. Use this to add the
+    /// reporter to a custom [`ll::TaskTree`] (e.g. in tests).
+    pub fn build_reporter(self) -> (Arc<dyn Reporter>, FlushGuard) {
+        let w = self.writer.expect("must set a file or writer");
+        let shared = Arc::new(Mutex::new(WriterState::new(w, &self.process_name)));
+        let reporter = TraceReporter {
+            state: shared.clone(),
+            include_args: self.include_args,
+            include_tags: self.include_tags,
+        };
+        (Arc::new(reporter), FlushGuard { state: shared })
+    }
+}
+
+// ── FlushGuard ──────────────────────────────────────────────────
+
+/// Finalizes the trace file on drop. Hold this until you're done tracing.
+pub struct FlushGuard {
+    state: Arc<Mutex<WriterState>>,
+}
+
+impl FlushGuard {
+    /// Manually flush and finalize the trace. Called automatically on drop.
+    pub fn flush(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.finalize();
+    }
+}
+
+impl Drop for FlushGuard {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+// ── Reporter ────────────────────────────────────────────────────
+
+struct TraceReporter {
+    state: Arc<Mutex<WriterState>>,
+    include_args: bool,
+    include_tags: bool,
+}
+
+impl Reporter for TraceReporter {
+    fn start(&self, queue: EventQueue) {
+        let state = self.state.clone();
+        let include_args = self.include_args;
+        let include_tags = self.include_tags;
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(Duration::from_millis(10));
+                let events = std::mem::take(&mut *queue.lock().unwrap());
+                if !events.is_empty() {
+                    let mut s = state.lock().unwrap();
+                    if !s.finalized {
+                        let epoch = s.epoch;
+                        let _ = writer::write_events(
+                            &mut s.writer,
+                            &events,
+                            epoch,
+                            include_args,
+                            include_tags,
+                        );
+                    }
+                }
+            }
+        });
+    }
+}
+
+// ── WriterState ─────────────────────────────────────────────────
+
+struct WriterState {
+    writer: Box<dyn Write + Send>,
+    epoch: SystemTime,
+    finalized: bool,
+}
+
+impl WriterState {
+    fn new(mut w: Box<dyn Write + Send>, process_name: &str) -> Self {
+        let epoch = SystemTime::now();
+        let _ = writer::write_header(&mut w, process_name);
+        WriterState {
+            writer: w,
+            epoch,
+            finalized: false,
+        }
+    }
+
+    fn finalize(&mut self) {
+        if self.finalized {
+            return;
+        }
+        self.finalized = true;
+        let _ = writer::write_footer(&mut self.writer);
+        let _ = self.writer.flush();
+    }
+}

--- a/ll_trace/src/lib.rs
+++ b/ll_trace/src/lib.rs
@@ -147,22 +147,20 @@ impl Reporter for TraceReporter {
         let state = self.state.clone();
         let include_args = self.include_args;
         let include_tags = self.include_tags;
-        std::thread::spawn(move || {
-            loop {
-                std::thread::sleep(Duration::from_millis(10));
-                let events = std::mem::take(&mut *queue.lock().unwrap());
-                if !events.is_empty() {
-                    let mut s = state.lock().unwrap();
-                    if !s.finalized {
-                        let epoch = s.epoch;
-                        let _ = writer::write_events(
-                            &mut s.writer,
-                            &events,
-                            epoch,
-                            include_args,
-                            include_tags,
-                        );
-                    }
+        std::thread::spawn(move || loop {
+            std::thread::sleep(Duration::from_millis(10));
+            let events = std::mem::take(&mut *queue.lock().unwrap());
+            if !events.is_empty() {
+                let mut s = state.lock().unwrap();
+                if !s.finalized {
+                    let epoch = s.epoch;
+                    let _ = writer::write_events(
+                        &mut s.writer,
+                        &events,
+                        epoch,
+                        include_args,
+                        include_tags,
+                    );
                 }
             }
         });

--- a/ll_trace/src/lib.rs
+++ b/ll_trace/src/lib.rs
@@ -104,12 +104,20 @@ impl Builder {
     pub fn build_reporter(self) -> (Arc<dyn Reporter>, FlushGuard) {
         let w = self.writer.expect("must set a file or writer");
         let shared = Arc::new(Mutex::new(WriterState::new(w, &self.process_name)));
+        let queue_slot: Arc<Mutex<Option<EventQueue>>> = Arc::new(Mutex::new(None));
         let reporter = TraceReporter {
             state: shared.clone(),
+            queue_slot: queue_slot.clone(),
             include_args: self.include_args,
             include_tags: self.include_tags,
         };
-        (Arc::new(reporter), FlushGuard { state: shared })
+        let guard = FlushGuard {
+            state: shared,
+            queue_slot,
+            include_args: self.include_args,
+            include_tags: self.include_tags,
+        };
+        (Arc::new(reporter), guard)
     }
 }
 
@@ -118,13 +126,32 @@ impl Builder {
 /// Finalizes the trace file on drop. Hold this until you're done tracing.
 pub struct FlushGuard {
     state: Arc<Mutex<WriterState>>,
+    queue_slot: Arc<Mutex<Option<EventQueue>>>,
+    include_args: bool,
+    include_tags: bool,
 }
 
 impl FlushGuard {
-    /// Manually flush and finalize the trace. Called automatically on drop.
+    /// Drain any remaining events and finalize the trace. Called automatically on drop.
     pub fn flush(&self) {
-        let mut state = self.state.lock().unwrap();
-        state.finalize();
+        let queue = self.queue_slot.lock().unwrap().clone();
+        if let Some(queue) = queue {
+            let events = std::mem::take(&mut *queue.lock().unwrap());
+            let mut state = self.state.lock().unwrap();
+            if !state.finalized && !events.is_empty() {
+                let epoch = state.epoch;
+                let _ = writer::write_events(
+                    &mut state.writer,
+                    &events,
+                    epoch,
+                    self.include_args,
+                    self.include_tags,
+                );
+            }
+            state.finalize();
+        } else {
+            self.state.lock().unwrap().finalize();
+        }
     }
 }
 
@@ -138,12 +165,14 @@ impl Drop for FlushGuard {
 
 struct TraceReporter {
     state: Arc<Mutex<WriterState>>,
+    queue_slot: Arc<Mutex<Option<EventQueue>>>,
     include_args: bool,
     include_tags: bool,
 }
 
 impl Reporter for TraceReporter {
     fn start(&self, queue: EventQueue) {
+        *self.queue_slot.lock().unwrap() = Some(queue.clone());
         let state = self.state.clone();
         let include_args = self.include_args;
         let include_tags = self.include_tags;

--- a/ll_trace/src/writer.rs
+++ b/ll_trace/src/writer.rs
@@ -1,0 +1,164 @@
+use ll::reporters::TaskEvent;
+use ll::task_tree::{TaskInternal, TaskResult, TaskStatus};
+use ll::DataValue;
+use serde::Serialize;
+use std::io::Write;
+use web_time::SystemTime;
+
+// ── Public API ──────────────────────────────────────────────────
+
+/// Write the JSON header that opens the trace file.
+pub fn write_header(w: &mut impl Write, process_name: &str) -> std::io::Result<()> {
+    write!(w, "{{\"traceEvents\":[\n")?;
+    let meta = TraceEvent {
+        ph: "M",
+        name: "process_name",
+        cat: "",
+        ts: 0.0,
+        dur: None,
+        pid: 1,
+        tid: 0,
+        args: Some(serde_json::json!({ "name": process_name })),
+    };
+    serde_json::to_writer(&mut *w, &meta)?;
+    Ok(())
+}
+
+/// Write the JSON footer that closes the trace file.
+pub fn write_footer(w: &mut impl Write) -> std::io::Result<()> {
+    write!(w, "\n]}}\n")
+}
+
+/// Convert a batch of task events into trace events and write them.
+/// Only `End` events produce output (as complete `X` events with duration).
+pub fn write_events(
+    w: &mut impl Write,
+    events: &[TaskEvent],
+    epoch: SystemTime,
+    include_args: bool,
+    include_tags: bool,
+) -> std::io::Result<()> {
+    for event in events {
+        let task = match event {
+            TaskEvent::End(t) => t,
+            _ => continue,
+        };
+        let trace = task_to_trace_event(task, epoch, include_args, include_tags);
+        write!(w, ",\n")?;
+        serde_json::to_writer(&mut *w, &trace)?;
+    }
+    Ok(())
+}
+
+// ── Internals ───────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct TraceEvent<'a> {
+    ph: &'a str,
+    name: &'a str,
+    cat: &'a str,
+    ts: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dur: Option<f64>,
+    pid: u64,
+    tid: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    args: Option<serde_json::Value>,
+}
+
+fn task_to_trace_event(
+    task: &TaskInternal,
+    epoch: SystemTime,
+    include_args: bool,
+    include_tags: bool,
+) -> TraceEvent<'_> {
+    let ts_us = to_micros(task.started_at, epoch);
+    let dur_us = match &task.status {
+        TaskStatus::Finished(_, end_time) => Some(to_micros(*end_time, epoch) - ts_us),
+        TaskStatus::Running => None,
+    };
+
+    let cat = extract_level_tag(task);
+
+    let args = build_args(task, include_args, include_tags);
+
+    TraceEvent {
+        ph: "X",
+        name: &task.name,
+        cat,
+        ts: ts_us,
+        dur: dur_us,
+        pid: 1,
+        tid: task.id.to_string().parse::<u64>().unwrap_or(0),
+        args,
+    }
+}
+
+fn to_micros(time: SystemTime, epoch: SystemTime) -> f64 {
+    time.duration_since(epoch)
+        .unwrap_or_default()
+        .as_secs_f64()
+        * 1_000_000.0
+}
+
+fn extract_level_tag(task: &TaskInternal) -> &'static str {
+    for tag in &task.tags {
+        match tag.as_str() {
+            "l0" => return "l0",
+            "l1" => return "l1",
+            "l2" => return "l2",
+            "l3" => return "l3",
+            _ => {}
+        }
+    }
+    "l1"
+}
+
+fn build_args(
+    task: &TaskInternal,
+    include_args: bool,
+    include_tags: bool,
+) -> Option<serde_json::Value> {
+    let mut map = serde_json::Map::new();
+
+    // status / error
+    match &task.status {
+        TaskStatus::Finished(TaskResult::Failure(msg), _) => {
+            map.insert("error".into(), serde_json::Value::String(msg.clone()));
+        }
+        _ => {}
+    }
+
+    // parent path
+    if !task.parent_names.is_empty() {
+        map.insert(
+            "parent".into(),
+            serde_json::Value::String(task.parent_names.join(" > ")),
+        );
+    }
+
+    // task data
+    if include_args {
+        for (key, entry) in &task.data.map {
+            let val = match &entry.0 {
+                DataValue::String(s) => serde_json::Value::String(s.clone()),
+                DataValue::Int(i) => serde_json::json!(i),
+                DataValue::Float(f) => serde_json::json!(f),
+                DataValue::None => serde_json::Value::Null,
+            };
+            map.insert(key.clone(), val);
+        }
+    }
+
+    // tags
+    if include_tags && !task.tags.is_empty() {
+        let tags: Vec<_> = task.tags.iter().cloned().collect();
+        map.insert("tags".into(), serde_json::json!(tags));
+    }
+
+    if map.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(map))
+    }
+}

--- a/ll_trace/src/writer.rs
+++ b/ll_trace/src/writer.rs
@@ -95,10 +95,7 @@ fn task_to_trace_event(
 }
 
 fn to_micros(time: SystemTime, epoch: SystemTime) -> f64 {
-    time.duration_since(epoch)
-        .unwrap_or_default()
-        .as_secs_f64()
-        * 1_000_000.0
+    time.duration_since(epoch).unwrap_or_default().as_secs_f64() * 1_000_000.0
 }
 
 fn extract_level_tag(task: &TaskInternal) -> &'static str {

--- a/ll_trace/src/writer.rs
+++ b/ll_trace/src/writer.rs
@@ -9,7 +9,7 @@ use web_time::SystemTime;
 
 /// Write the JSON header that opens the trace file.
 pub fn write_header(w: &mut impl Write, process_name: &str) -> std::io::Result<()> {
-    write!(w, "{{\"traceEvents\":[\n")?;
+    writeln!(w, "{{\"traceEvents\":[")?;
     let meta = TraceEvent {
         ph: "M",
         name: "process_name",
@@ -44,7 +44,7 @@ pub fn write_events(
             _ => continue,
         };
         let trace = task_to_trace_event(task, epoch, include_args, include_tags);
-        write!(w, ",\n")?;
+        writeln!(w, ",")?;
         serde_json::to_writer(&mut *w, &trace)?;
     }
     Ok(())
@@ -119,11 +119,8 @@ fn build_args(
     let mut map = serde_json::Map::new();
 
     // status / error
-    match &task.status {
-        TaskStatus::Finished(TaskResult::Failure(msg), _) => {
-            map.insert("error".into(), serde_json::Value::String(msg.clone()));
-        }
-        _ => {}
+    if let TaskStatus::Finished(TaskResult::Failure(msg), _) = &task.status {
+        map.insert("error".into(), serde_json::Value::String(msg.clone()));
     }
 
     // parent path

--- a/ll_trace/tests/basic_test.rs
+++ b/ll_trace/tests/basic_test.rs
@@ -1,0 +1,141 @@
+use anyhow::Result;
+use ll::task_tree::TaskTree;
+use std::sync::Arc;
+
+/// A writer that appends to a shared buffer.
+#[derive(Clone)]
+struct SharedWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn setup_shared() -> (Arc<TaskTree>, SharedWriter, ll_trace::FlushGuard) {
+    let shared_buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let writer = SharedWriter(shared_buf.clone());
+
+    let (reporter, guard) = ll_trace::builder()
+        .writer(writer.clone())
+        .process_name("test")
+        .build_reporter();
+
+    let tt = TaskTree::new();
+    tt.add_reporter(reporter);
+
+    (tt, writer, guard)
+}
+
+#[tokio::test]
+async fn basic_trace_output() -> Result<()> {
+    let (tt, writer, guard) = setup_shared();
+
+    let root = tt.create_task("root");
+    root.spawn_sync("child_a", |t| {
+        t.data("key", "value");
+        Ok(())
+    })?;
+    root.spawn_sync("child_b", |_| Ok(()))?;
+    drop(root);
+
+    // Give the drain thread time to process events
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    guard.flush();
+
+    let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
+
+    // Should be valid JSON
+    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let events = parsed["traceEvents"].as_array().unwrap();
+
+    // First event is the metadata event
+    assert_eq!(events[0]["ph"], "M");
+    assert_eq!(events[0]["name"], "process_name");
+    assert_eq!(events[0]["args"]["name"], "test");
+
+    // Remaining events are complete (X) events for finished tasks
+    let task_events: Vec<_> = events.iter().filter(|e| e["ph"] == "X").collect();
+
+    // We expect events for: root, child_a, child_b
+    let names: Vec<_> = task_events.iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"child_a"));
+    assert!(names.contains(&"child_b"));
+    assert!(names.contains(&"root"));
+
+    // child_a should have args with the data
+    let child_a = task_events.iter().find(|e| e["name"] == "child_a").unwrap();
+    assert_eq!(child_a["args"]["key"], "value");
+
+    // All task events should have ts and dur
+    for event in &task_events {
+        assert!(event["ts"].as_f64().is_some());
+        assert!(event["dur"].as_f64().is_some());
+        assert_eq!(event["pid"], 1);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn error_task_includes_error_in_args() -> Result<()> {
+    let (tt, writer, guard) = setup_shared();
+
+    let root = tt.create_task("root");
+    let _: Result<()> = root.spawn_sync("failing", |_| {
+        anyhow::bail!("something went wrong");
+    });
+    drop(root);
+
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    guard.flush();
+
+    let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
+    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let events = parsed["traceEvents"].as_array().unwrap();
+
+    let failing = events.iter().find(|e| e["name"] == "failing").unwrap();
+    assert!(failing["args"]["error"].as_str().unwrap().contains("something went wrong"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn no_args_when_disabled() -> Result<()> {
+    let shared_buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let writer = SharedWriter(shared_buf.clone());
+
+    let (reporter, guard) = ll_trace::builder()
+        .writer(writer.clone())
+        .process_name("test")
+        .include_args(false)
+        .include_tags(false)
+        .build_reporter();
+
+    let tt = TaskTree::new();
+    tt.add_reporter(reporter);
+
+    let root = tt.create_task("root");
+    root.spawn_sync("task_with_data", |t| {
+        t.data("should_not_appear", "hidden");
+        Ok(())
+    })?;
+    drop(root);
+
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    guard.flush();
+
+    let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
+    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let events = parsed["traceEvents"].as_array().unwrap();
+
+    let task = events.iter().find(|e| e["name"] == "task_with_data").unwrap();
+    // Should not contain the data key (args may still have parent path)
+    assert!(task["args"].get("should_not_appear").is_none());
+
+    Ok(())
+}

--- a/ll_trace/tests/basic_test.rs
+++ b/ll_trace/tests/basic_test.rs
@@ -62,7 +62,10 @@ async fn basic_trace_output() -> Result<()> {
     let task_events: Vec<_> = events.iter().filter(|e| e["ph"] == "X").collect();
 
     // We expect events for: root, child_a, child_b
-    let names: Vec<_> = task_events.iter().map(|e| e["name"].as_str().unwrap()).collect();
+    let names: Vec<_> = task_events
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
     assert!(names.contains(&"child_a"));
     assert!(names.contains(&"child_b"));
     assert!(names.contains(&"root"));
@@ -99,7 +102,10 @@ async fn error_task_includes_error_in_args() -> Result<()> {
     let events = parsed["traceEvents"].as_array().unwrap();
 
     let failing = events.iter().find(|e| e["name"] == "failing").unwrap();
-    assert!(failing["args"]["error"].as_str().unwrap().contains("something went wrong"));
+    assert!(failing["args"]["error"]
+        .as_str()
+        .unwrap()
+        .contains("something went wrong"));
 
     Ok(())
 }
@@ -133,7 +139,10 @@ async fn no_args_when_disabled() -> Result<()> {
     let parsed: serde_json::Value = serde_json::from_str(&output)?;
     let events = parsed["traceEvents"].as_array().unwrap();
 
-    let task = events.iter().find(|e| e["name"] == "task_with_data").unwrap();
+    let task = events
+        .iter()
+        .find(|e| e["name"] == "task_with_data")
+        .unwrap();
     // Should not contain the data key (args may still have parent path)
     assert!(task["args"].get("should_not_appear").is_none());
 

--- a/ll_trace/tests/basic_test.rs
+++ b/ll_trace/tests/basic_test.rs
@@ -31,6 +31,12 @@ fn setup_shared() -> (Arc<TaskTree>, SharedWriter, ll_trace::FlushGuard) {
     (tt, writer, guard)
 }
 
+fn read_trace(writer: &SharedWriter, guard: &ll_trace::FlushGuard) -> serde_json::Value {
+    guard.flush();
+    let output = String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
+    serde_json::from_str(&output).unwrap()
+}
+
 #[tokio::test]
 async fn basic_trace_output() -> Result<()> {
     let (tt, writer, guard) = setup_shared();
@@ -43,14 +49,7 @@ async fn basic_trace_output() -> Result<()> {
     root.spawn_sync("child_b", |_| Ok(()))?;
     drop(root);
 
-    // Give the drain thread time to process events
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    guard.flush();
-
-    let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
-
-    // Should be valid JSON
-    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let parsed = read_trace(&writer, &guard);
     let events = parsed["traceEvents"].as_array().unwrap();
 
     // First event is the metadata event
@@ -94,11 +93,7 @@ async fn error_task_includes_error_in_args() -> Result<()> {
     });
     drop(root);
 
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    guard.flush();
-
-    let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
-    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let parsed = read_trace(&writer, &guard);
     let events = parsed["traceEvents"].as_array().unwrap();
 
     let failing = events.iter().find(|e| e["name"] == "failing").unwrap();
@@ -132,11 +127,7 @@ async fn no_args_when_disabled() -> Result<()> {
     })?;
     drop(root);
 
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    guard.flush();
-
-    let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
-    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let parsed = read_trace(&writer, &guard);
     let events = parsed["traceEvents"].as_array().unwrap();
 
     let task = events

--- a/ll_trace/tests/basic_test.rs
+++ b/ll_trace/tests/basic_test.rs
@@ -44,7 +44,7 @@ async fn basic_trace_output() -> Result<()> {
     drop(root);
 
     // Give the drain thread time to process events
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    std::thread::sleep(std::time::Duration::from_millis(100));
     guard.flush();
 
     let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
@@ -132,7 +132,7 @@ async fn no_args_when_disabled() -> Result<()> {
     })?;
     drop(root);
 
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    std::thread::sleep(std::time::Duration::from_millis(100));
     guard.flush();
 
     let output = String::from_utf8(writer.0.lock().unwrap().clone())?;
@@ -142,9 +142,12 @@ async fn no_args_when_disabled() -> Result<()> {
     let task = events
         .iter()
         .find(|e| e["name"] == "task_with_data")
-        .unwrap();
-    // Should not contain the data key (args may still have parent path)
-    assert!(task["args"].get("should_not_appear").is_none());
+        .expect("task_with_data event not found in trace");
+    // args should either be absent or not contain the data key
+    match task.get("args").and_then(|a| a.as_object()) {
+        Some(args) => assert!(!args.contains_key("should_not_appear")),
+        None => {} // no args at all — that's fine
+    }
 
     Ok(())
 }

--- a/ll_trace/tests/basic_test.rs
+++ b/ll_trace/tests/basic_test.rs
@@ -135,9 +135,8 @@ async fn no_args_when_disabled() -> Result<()> {
         .find(|e| e["name"] == "task_with_data")
         .expect("task_with_data event not found in trace");
     // args should either be absent or not contain the data key
-    match task.get("args").and_then(|a| a.as_object()) {
-        Some(args) => assert!(!args.contains_key("should_not_appear")),
-        None => {} // no args at all — that's fine
+    if let Some(args) = task.get("args").and_then(|a| a.as_object()) {
+        assert!(!args.contains_key("should_not_appear"));
     }
 
     Ok(())

--- a/test/ll_test_cli/Cargo.toml
+++ b/test/ll_test_cli/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 ll = { path = "../../ll" }
 ll_stdio = { path = "../../ll_stdio" }
+ll_trace = { path = "../../ll_trace" }
 ll_fixtures = { path = "../ll_fixtures" }
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/test/ll_test_cli/src/main.rs
+++ b/test/ll_test_cli/src/main.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> Result<()> {
     ll_stdio::builder().max_log_level(Level::L3).init();
+    let _trace = ll_trace::init("trace.json");
 
     let root = Task::create_new("pipeline #nostatus #l0");
     root.data_transitive("run_id", "test-run-42");


### PR DESCRIPTION
New reporter crate that writes Chrome Trace Event Format JSON, viewable in chrome://tracing or Perfetto UI. Each finished task becomes a complete (X) event with timestamp, duration, and optional metadata (task data, tags, error messages, parent path).

The reporter streams JSON incrementally via a background drain thread (same pattern as StdioReporter). A FlushGuard finalizes the trace file on drop by writing the closing `]}`.

API:
  let _guard = ll_trace::init("trace.json");
  // or: ll_trace::builder().file("trace.json").process_name("my-server").build();

Also exposes build_reporter() for adding to a custom TaskTree in tests.